### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/app/services/retell_service.py
+++ b/app/services/retell_service.py
@@ -13,7 +13,8 @@ class RetellService:
         self.webhook_url = settings.retell_webhook_url
         self.agent_id = settings.retell_agent_id
         self.api_base = settings.retell_api_base
-        logger.info(f"Initialized RetellService with phone number: {self.phone_number}")
+        masked_phone_number = self.phone_number[:2] + "****" + self.phone_number[-2:]
+        logger.info(f"Initialized RetellService with phone number: {masked_phone_number}")
 
     async def schedule_call(
         self,


### PR DESCRIPTION
Potential fix for [https://github.com/Schless09/anita_fastapi/security/code-scanning/3](https://github.com/Schless09/anita_fastapi/security/code-scanning/3)

To fix the problem, we should avoid logging sensitive information such as phone numbers in clear text. Instead, we can log a masked version of the phone number or omit it entirely from the logs. This ensures that sensitive data is not exposed while still providing useful logging information.

The best way to fix this without changing existing functionality is to mask the phone number before logging it. We can replace the middle digits of the phone number with asterisks, leaving only the last few digits visible. This approach maintains some level of information in the logs without exposing the full phone number.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
