### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/app/services/candidate_service.py
+++ b/app/services/candidate_service.py
@@ -86,7 +86,7 @@ class CandidateService:
         insert_data = {k: v for k, v in insert_data.items() if v is not None}
         
         # --- DEBUG LOGGING --- 
-        logger.info(f"Data prepared for Supabase insert: {insert_data}")
+        logger.info("Data prepared for Supabase insert.")
         # --- END DEBUG LOGGING ---
 
         try:


### PR DESCRIPTION
Potential fix for [https://github.com/Schless09/anita_fastapi/security/code-scanning/7](https://github.com/Schless09/anita_fastapi/security/code-scanning/7)

To fix the problem, we need to avoid logging sensitive information such as email addresses and phone numbers. Instead, we can log non-sensitive information or anonymize the sensitive data before logging. In this case, we can remove the detailed logging of `insert_data` or replace it with a log statement that does not include sensitive information.

The best way to fix the problem without changing existing functionality is to modify the log statement on line 89 to exclude sensitive data. We can log a message indicating that data has been prepared for insertion without including the actual data.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
