### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -150,7 +150,7 @@ async def submit_job(job_data: JobPosting, job_service: JobService = Depends(get
             logger.info(f"Nice to Have: {', '.join(job_data.tech_stack_nice_to_haves)}")
         
         # Log compensation info
-        logger.info(f"Salary Range: ${job_data.salary_range_min} - ${job_data.salary_range_max}")
+        logger.info("Salary Range information received.")
         
         # Add job ID and timestamps
         job_id = str(uuid.uuid4())


### PR DESCRIPTION
Potential fix for [https://github.com/Schless09/anita_fastapi/security/code-scanning/2](https://github.com/Schless09/anita_fastapi/security/code-scanning/2)

To fix the problem, we should avoid logging sensitive information such as salary ranges in clear text. Instead, we can log a generic message indicating that salary information is present without revealing the actual values. This approach maintains the functionality of logging key events without exposing sensitive data.

- Replace the logging statement that includes the salary range with a more generic message.
- Ensure that no sensitive information is logged in clear text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
