### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/app/api/webhook.py
+++ b/app/api/webhook.py
@@ -276,4 +276,4 @@ async def handler(
 
     except Exception as e:
         logger.error(f"❌ Error processing webhook: {str(e)}\nTraceback: {traceback.format_exc()}")
-        return JSONResponse(status_code=500, content={"status": "error", "message": str(e)}) # Return 500 on unexpected errors 
+        return JSONResponse(status_code=500, content={"status": "error", "message": "An internal error has occurred. Please try again later."}) # Return 500 on unexpected errors 


### PR DESCRIPTION
Potential fix for [https://github.com/Schless09/anita_fastapi/security/code-scanning/4](https://github.com/Schless09/anita_fastapi/security/code-scanning/4)

To fix the problem, we need to ensure that the detailed exception message is not returned to the user. Instead, we should return a generic error message while logging the detailed error message and stack trace on the server. This can be achieved by modifying the code in the `handler` function to return a generic error message in the JSON response.

1. Modify the `handler` function to return a generic error message in the JSON response.
2. Ensure that the detailed error message and stack trace are logged on the server for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
