### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/app/agents/brain_agent.py
+++ b/app/agents/brain_agent.py
@@ -408,8 +408,11 @@ class BrainAgent:
                     'previous_title_2': previous_title_2 or 'Second Previous Title'  
                 }
                 
-                # Log the dynamic variables being sent
-                logger.info(f"Dynamic variables for Retell call: {json.dumps(dynamic_variables)}")
+                # Remove sensitive information before logging
+                sanitized_dynamic_variables = dynamic_variables.copy()
+                sanitized_dynamic_variables.pop('phone', None)
+                sanitized_dynamic_variables.pop('email', None)
+                logger.info(f"Dynamic variables for Retell call: {json.dumps(sanitized_dynamic_variables)}")
 
                 # Schedule call using retell_service
                 call_result = await self.retell_service.schedule_call(


### PR DESCRIPTION
Potential fix for [https://github.com/Schless09/anita_fastapi/security/code-scanning/6](https://github.com/Schless09/anita_fastapi/security/code-scanning/6)

To fix the problem, we should avoid logging sensitive information in clear text. Instead, we can log non-sensitive parts of the data or mask the sensitive information before logging. In this case, we will remove sensitive fields such as 'phone' and 'email' from the `dynamic_variables` dictionary before logging it.

- Identify the lines where sensitive information is logged.
- Remove or mask sensitive information from the data before logging.
- Ensure that the logging still provides useful information without exposing sensitive data.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
