### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/app/services/retell_service.py
+++ b/app/services/retell_service.py
@@ -14,7 +14,7 @@ class RetellService:
         self.webhook_url = settings.retell_webhook_url
         self.agent_id = settings.retell_agent_id
         self.api_base = settings.retell_api_base
-        logger.info(f"Initialized RetellService with phone number: {self.phone_number}")
+        logger.info("Initialized RetellService")
 
     async def schedule_call(
         self,


### PR DESCRIPTION
Potential fix for [https://github.com/Schless09/anita_fastapi/security/code-scanning/3](https://github.com/Schless09/anita_fastapi/security/code-scanning/3)

To fix the problem, we should avoid logging the phone number directly. Instead, we can log a message that indicates the initialization of the `RetellService` without including the sensitive phone number. This way, we maintain the functionality of logging important events without exposing sensitive information.

- Remove the phone number from the log message on line 17.
- Update the log message to indicate the initialization of the `RetellService` without including sensitive data.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
